### PR TITLE
凍結対策

### DIFF
--- a/.idea/HoloDexBackEnd.iml
+++ b/.idea/HoloDexBackEnd.iml
@@ -1,2 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module type="JAVA_MODULE" version="4" />
+<module external.linked.project.id="HoloDexBackEnd" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$" external.system.id="GRADLE" external.system.module.group="org.example" external.system.module.version="1.0-SNAPSHOT" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.gradle" />
+      <excludeFolder url="file://$MODULE_DIR$/build" />
+      <excludeFolder url="file://$MODULE_DIR$/out" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/HoloDexBackEnd.iml" filepath="$PROJECT_DIR$/.idea/HoloDexBackEnd.iml" />
+    </modules>
+  </component>
+</project>

--- a/src/main/java/Input.kt
+++ b/src/main/java/Input.kt
@@ -2,6 +2,7 @@ import com.squareup.moshi.Moshi
 import com.squareup.moshi.Types
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import okio.Okio
+import java.io.File
 
 data class InputHololiver(
     val id: Int?,
@@ -14,7 +15,15 @@ data class InputHololiver(
 )
 
 interface Input {
+    /**
+     * Read from MasterData.json
+     */
     fun read(): List<InputHololiver>
+
+    /**
+     * Restore last Data
+     */
+    fun restoreData(): List<OutputHololiver>
 }
 
 class InputImpl : Input {
@@ -30,5 +39,25 @@ class InputImpl : Input {
         val json = adapter.fromJson(bufferedSource)
 
         return json!!
+    }
+
+    override fun restoreData(): List<OutputHololiver> {
+        val type = Types.newParameterizedType(List::class.java, OutputHololiver::class.java)
+
+        val adapter = Moshi.Builder()
+            .add(KotlinJsonAdapterFactory())
+            .build().adapter<List<OutputHololiver>>(type)
+
+        val file = File("public/members.json")
+
+        if (!file.exists()) {
+            return listOf()
+        }
+
+        val source = Okio.buffer(Okio.source(file)).readUtf8()
+
+        val restoreList = adapter.fromJson(source)
+
+        return restoreList ?: listOf()
     }
 }


### PR DESCRIPTION
凍結されていてtwitterからのデータが取得できない場合、古いデータを復元するように修正
close #2